### PR TITLE
repairing rules editor in web client, fixes #11

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -109,7 +109,7 @@
             <div class='span8'>
               <div class='rule-list'>
                 <ol>
-                  <li ng-repeat='rule in rules' >
+                  <li ng-repeat='rule in rules track by $index' >
                     <a ng-click='editRule($index)'>{{rule.name}}</a>
                   </li>
                 </ol>

--- a/client/js/rules.js
+++ b/client/js/rules.js
@@ -1,7 +1,7 @@
 function RuleListCtrl($scope, ScanSvc) {
   //if copy of rules in localStorage use that, else load from original
   $scope.current={};
-  editing=-1;
+  var editing=-1;
   $scope.rules=[];
   
   $scope.editRule=function(ruleid){
@@ -11,11 +11,11 @@ function RuleListCtrl($scope, ScanSvc) {
   $scope.saveRule=function(){
     if(editing){
       $scope.rules[editing]={
-        type:current.type,
-        name:current.name,
-        test:current.test,
-        desc:current.desc,
-        rec:current.rec
+        type: $scope.current.type,
+        name: $scope.current.name,
+        test: $scope.current.test,
+        desc: $scope.current.desc,
+        rec: $scope.current.rec
       }
     }
     localStorage.setItem('rules', JSON.stringify($scope.rules));


### PR DESCRIPTION
Possibly due to a change in angular.js, the creation of `$index` must now be explicitly requested. Additionally, the `current` identifier was used when `$scope.current` was meant.

Slightly unrelated, but I've taken the liberty to bind `editing` to the correct variable scope

Will you review and merge @pwnetrationguru? :)
