### PR TITLE
adding empty href attributes to links

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -34,7 +34,7 @@
           <span class="span6">
             <ul>
               <li ng-repeat="file in inputFiles track by $index">
-                <a ng-click="updateCodeMirror($index)"
+                <a href="#" ng-click="updateCodeMirror($index)"
                    title="Examine file in preview">{{file.name}}</a>
             </ul>
           </span>
@@ -56,7 +56,7 @@
                 </span>
                   <ul>
                     <li ng-repeat='result in ruleresult'>
-                      <a ng-mouseover="setCursor(fileResult.filename,result.line, result.col)"
+                      <a href="#" ng-mouseover="setCursor(fileResult.filename,result.line, result.col)"
                          title="Click to highlight the affected line in the editor">Line {{result.line}}:</a><br>
                     </li>
                   </ul>
@@ -79,7 +79,7 @@
           <div class='rule-list'>
             <ol>
               <li ng-repeat='rule in rules track by $index'>
-                <a ng-click='editRule($index)'>{{rule.name}}</a>
+                <a href="#" ng-click='editRule($index)'>{{rule.name}}</a>
               </li>
             </ol>
           </div>


### PR DESCRIPTION
If we add `href="#"` to our `<a>` tags, we get the mouse cursors for links, not those for text :)
