### PR TITLE
remove commented out code, fixes #34

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,12 +62,6 @@ if( typeof process != 'undefined' && process.argv[2]) {
       var ext = path.extname(file.toString());
 
       if(ext == '.js') {
-
-        /*copy to report dir
-        TODO: createOption to copy content to report - copying to file system doesn't work if we want a self-contained report format
-        var copiedName = fullpath.substr(argv.t.length).replace(/\//g,"_");
-        fs.createReadStream(fullpath).pipe(fs.createWriteStream(reportname + '_files/' + copiedName));
-        */
         var content = fs.readFileSync(fullpath, 'utf8');
         try {
           results[fullpath] = ScanJS.scan(content, signatures, fullpath);


### PR DESCRIPTION
Paul and I agreed that this isn't a super useful feature either.
His original idea was creating a copy of the scanned files for referencing them via file:// URLs.

Let's just remove it...
