### PR TITLE
fixing arguments.join is not a function error

### DIFF
--- a/client/js/scanworker.js
+++ b/client/js/scanworker.js
@@ -2,8 +2,8 @@
    We won't see the message though, since this kind of postMessage isn't handled in scanservice.js  */
 if (typeof console === "undefined") {
   console = {};
-  console.log = function consoleShim() {
-    postMessage({'type':'log', 'message': arguments.join(" ")});
+  console.log = function consoleShim(mesg) {
+    postMessage({'type':'log', 'message': mesg});
   }
 }
 


### PR DESCRIPTION
Fixes #67 

Fixes arguments.join is not a function error. However, now we only take the first argument to `console.log` and feed it to postMessage. I think this is fine since we basically do nothing we these postMessages anyways.
