### PR TITLE
Wrap stat call in try/catch to prevent crash when we encounter a bad symlink

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,11 @@ var dive = function(dir, action) {
   list = fs.readdirSync(dir);
   list.forEach(function(file) {
     var fullpath = dir + '/' + file;
-    var stat = fs.statSync(fullpath);
+    try {
+      var stat = fs.statSync(fullpath);
+    } catch(e) {
+      console.log("SKIPPING FILE: Could not stat " + fullpath);
+    }
     if(stat && stat.isDirectory()) {
       dive(fullpath, action);
     } else {


### PR DESCRIPTION
There are apps in the market tarballs with bad symlinks. The call to fs.statSync throws an exception which needs to be caught, or ScanJS crashes. 
