### PR TITLE
Add 'Export' functionality to print summarized report

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -155,7 +155,7 @@
             </table>
       </div>
 
-      <div id="report-wrapper" class="panel" ng-show="(results.length != 0)">
+      <div id="report-wrapper" ng-show="(results.length != 0)">
 	<h4>Report<span class="badge pull-right">{{reportLength}}</span></h4>
 	<div class="jumbotron col-md-12">
 	  <span class="pull-right">

--- a/client/js/scanctrl.js
+++ b/client/js/scanctrl.js
@@ -285,7 +285,6 @@ function ScanCtrl($scope, ScanSvc) {
   $scope.export = function() {
     document.getElementById('report').innerHTML = "";
     $scope.reportLength = 0;
-    $scope.$apply();
     localforage.getItem('results', function (results_storage) {
       if(!results_storage){
         alert('There are no results to export')


### PR DESCRIPTION
Very simple for now, but this functionality allows a user to generate a summarized reports. This is useful for many things, obviously, but we are mainly interested in being able to take a "snapshot" or "fingerprint" of the application's current start during a review.

The outputed report looks similar to:

```

filename, rule name, line
accessibility.js, setTimeout, [98, 142]
action_menu.js, .innerHTML , [58]
action_menu.js, setTimeout, [92]
activities.js, setTimeout, [54]
airplane_mode.js, setTimeout, [452]
app_chrome.js, setTimeout, [132, 244, 253]
app_install_manager.js, .innerHTML , [307, 313]
app_modal_dialog.js, .innerHTML , [219, 228, 237]
app_window.js, setTimeout, [501, 770, 775, 790, 1318, 1327, 1338]
app_window.js, .href=, [1178]
app_window.js, .src, [1187, 1297, 1301]
attention_screen.js, .bar=, [18]
attention_screen.js, setTimeout, [173, 181, 256, 302]
battery_manager.js, setTimeout, [131]
bluetooth_transfer.js, setTimeout, [294]
bluetooth_transfer.js, .innerHTML , [348]
```

The report is not generated until a user clicks "Export', so there are no performance implications.
