### PR TITLE
New rules for APIs

### DIFF
--- a/common/rules.json
+++ b/common/rules.json
@@ -416,6 +416,62 @@
     "threat": ""
   },
   {
+    "name": "audio-channel-content permission",
+    "source": "$.mozAudioChannel=$",
+    "testhit": "ringtonePlayer.mozAudioChannel = 'content';",
+    "testmiss": "",
+    "desc": "This function is only available to higher privileged Firefox OS applications.",
+    "threat": ""
+  },
+  {
+    "name": "audio-channel-alarm permission",
+    "source": "$.mozAudioChannel=$",
+    "testhit": "ringtonePlayer.mozAudioChannel = 'alarm'",
+    "testmiss": "",
+    "desc": "This function is only available to higher privileged Firefox OS applications.",
+    "threat": ""
+  },
+  {
+    "name": "audio-channel-normal permission",
+    "source": "$.mozAudioChannel=$",
+    "testhit": "ringtonePlayer.mozAudioChannel = 'normal'",
+    "testmiss": "",
+    "desc": "This function is only available to higher privileged Firefox OS applications.",
+    "threat": ""
+  },
+  {
+    "name": "audio-channel-notification permission",
+    "source": "$.mozAudioChannel=$",
+    "testhit": "ringtonePlayer.mozAudioChannel = 'notification'",
+    "testmiss": "",
+    "desc": "This function is only available to higher privileged Firefox OS applications.",
+    "threat": ""
+  },
+  {
+    "name": "audio-channel-publicnotification permission",
+    "source": "$.mozAudioChannel=$",
+    "testhit": "ringtonePlayer.mozAudioChannel = 'publicnotification'",
+    "testmiss": "",
+    "desc": "This function is only available to higher privileged Firefox OS applications.",
+    "threat": ""
+  },
+  {
+    "name": "audio-channel-ringer permission",
+    "source": "$.mozAudioChannel=$",
+    "testhit": "ringtonePlayer.mozAudioChannel = 'ringer'",
+    "testmiss": "",
+    "desc": "This function is only available to higher privileged Firefox OS applications.",
+    "threat": ""
+  },
+  {
+    "name": "audio-channel-telephony permission",
+    "source": "$.mozAudioChannel=$",
+    "testhit": "ringtonePlayer.mozAudioChannel = 'telephony'",
+    "testmiss": "",
+    "desc": "This function is only available to higher privileged Firefox OS applications.",
+    "threat": ""
+  },
+  {
     "name": "background-sensors permission",
     "source": "$.addEventListener('deviceproximity', callback)",
     "testhit": "window.addEventListener('deviceproximity', callback)",
@@ -768,63 +824,35 @@
     "threat": "Certified API"
   },
   {
-    "source":"navigator.mozWifiManager",
-    "testhit":"navigator.mozWifiManager",
-    "testmiss":null,
-    "desc":"This function is only available to higher privileged Firefox OS applications. It allows managing the Wifi features of the phone.","threat":"Certified API"
+    "name": "mozkeyboard",
+    "source": "navigator.mozKeyboard",
+    "testhit": "var keyboard = navigator.mozKeyboard || navigator.mozInputMethod;",
+    "testmiss": "",
+    "desc": "Usage of sensitive API",
+    "threat": ""
   },
   {
-    "source":"navigator.mozKeyboard",
-    "testhit":"var keyboard = navigator.mozKeyboard || navigator.mozInputMethod;",
-    "testmiss":null,
-    "desc":"Usage of sensitive API","threat":""
+    "name": "cell broadcasts",
+    "source": "navigator.mozCellBroadcast",
+    "testhit": "navigator.mozCellBroadcast.onreceived = this.show.bind(this);",
+    "testmiss": "",
+    "desc": "Usage of sensitive API",
+    "threat": ""
   },
   {
-    "source":"navigator.mozCellBroadcast",
-    "testhit":"navigator.mozCellBroadcast.onreceived = this.show.bind(this);",
-    "testmiss":null,
-    "desc":"Usage of sensitive API","threat":""
+    "name": "mobile connection api",
+    "source": "navigator.mozMobileConnection",
+    "testhit": "var conn = window.navigator.mozMobileConnection || window.navigator.mozMobileConnections",
+    "testmiss": "",
+    "desc": "Usage of sensitive API",
+    "threat": ""
   },
   {
-    "source":"navigator.mozMobileConnection",
-    "testhit":"var conn = window.navigator.mozMobileConnection || window.navigator.mozMobileConnections",
-    "testmiss":null,
-    "desc":"Usage of sensitive API","threat":""
-  },
-  {
-    "source":"navigator.mozMobileConnections",
-    "testhit":"var conn = window.navigator.mozMobileConnection || window.navigator.mozMobileConnections",
-    "testmiss":null,
-    "desc":"Usage of sensitive API","threat":""
-  },
-  {
-    "source":"navigator.mozNotification",
-    "testhit":"var notification = navigator.mozNotification.createNotification(title, body, icon);",
-    "testmiss":null,
-    "desc":"Usage of sensitive API","threat":""
-  },
-  {
-    "source":"navigator.mozSms",
-    "testhit":"window.navigator.mozSms.onreceived = func;",
-    "testmiss":null,
-    "desc":"Usage of sensitive API","threat":""
-  },
-  {
-    "source":"$.mozAudioChannel",
-    "testhit":"ringer.mozAudioChannel = 'content';",
-    "testmiss":null,
-    "desc":"Usage of sensitive API","threat":""
-  },
-  {
-    "source":"$.addEventListener('moznetworkupload',",
-    "testhit":"window.addEventListener('moznetworkupload', _onNetworkActivity);",
-    "testmiss":null,
-    "desc":"Usage of sensitive API","threat":""
-  },
-  {
-    "source":"$.addEventListener('moznetworkdownload',",
-    "testhit":"window.addEventListener('moznetworkdownload', _onNetworkActivity);",
-    "testmiss":null,
-    "desc":"Usage of sensitive API","threat":""
+    "name": "notification api",
+    "source": "navigator.mozNotification",
+    "testhit": "var notification = navigator.mozNotification.createNotification(title, body, icon);",
+    "testmiss": "",
+    "desc": "Usage of sensitive API",
+    "threat": ""
   }
 ]


### PR DESCRIPTION
This reduces test failures in moz.js - Some tests are not really doing what the rules suggest, and I'd prefer solving this somewhere else than making the tests say what the rules do ;)
e.g.

"window.navigator.mozWifiManager" should be caught by the `navigator.mozWifiManager` rule. But if I rewrite the test to $.navigator.mozWifimanager` it stops finding the case without window before it...
