### PR TITLE
Improves server-side ScanJS installation, usage, and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,8 @@ Run ScanJS in the browser
 Run ScanJS from the command line
 ------------------------
 - Install [node.js](http://nodejs.org/)
-- ```git clone https://github.com/mozilla/scanjs.git```
-- ```cd scanjs```
-- ```npm install```
-- ```node scanner.js -t DIRECTORY_PATH```
+- ```npm install -g mozilla/scanjs```
+- ```scanjs -t DIRECTORY_PATH```
 
 Testing instructions
 ------------------------

--- a/package.json
+++ b/package.json
@@ -2,7 +2,11 @@
   "name": "scanjs",
   "version": "0.0.2",
   "description": "Static analysis tool for javascript codebases",
-  "main": "index.js",
+  "main": "scanner.js",
+  "bin": {
+    "scanjs": "./scanner.js"
+  },
+  "preferGlobal": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/mozilla/scanjs.git"

--- a/scanner.js
+++ b/scanner.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /*jshint node:true*/
 
 // This script is for using scanjs server side


### PR DESCRIPTION
Please run `npm publish` and change `npm install -g mozilla/scanjs` to `npm install -g scanjs`!
